### PR TITLE
Fix TSC build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "main": "dist/index.js",
     "type": "module",
     "scripts": {
-        "build": "rm -rf dist && pnpm tsc",
+        "build": "rm -rf dist && pnpm tsc -p tsconfig-build.json",
         "dev": "pnpm build && node ./dist/index.js",
         "lint": "pnpm exec eslint src/**/* ",
         "lint:fix": "pnpm exec eslint src/**/* --fix",

--- a/tsconfig-build.json
+++ b/tsconfig-build.json
@@ -1,0 +1,6 @@
+{
+	"extends": "./tsconfig.json",
+	"exclude": [
+		"**/__tests__"
+	]
+}


### PR DESCRIPTION
Before, the tests and src folder was being compiled, we want typescript for compilation and IDE but not for building, so I made a seperate tsconfig file that extends the current one and excludes it. The `pn build` command is updated to add the `-p` flag that uses the config file provided.